### PR TITLE
Fix Server Error on Checkout Page

### DIFF
--- a/templates/pages/checkout.html
+++ b/templates/pages/checkout.html
@@ -18,7 +18,7 @@
         <h1 class="is-srOnly">{{lang 'checkout.title'}}</h1>
         <h2 class="checkoutHeader-heading">
             <a class="checkoutHeader-link" href="{{urls.home}}">
-                {{/if checkout.header_image}}
+                {{#if checkout.header_image}}
                     <img alt="{{settings.store_logo.title}}" class="checkoutHeader-logo" id="logoImage" src="{{ checkout.header_image }}"/>
                 {{ else }}
                     <span class="header-logo-text">{{settings.store_logo.title}}</span>


### PR DESCRIPTION
Current implementation uses a # character for the 'if' Handlebars helper. This causes a syntax error and the result is a 500 server error when reaching the checkout page.